### PR TITLE
Avoid failure if the MySQL daemon startup is slow

### DIFF
--- a/jeedom-all-in-one/docker-entrypoint.sh
+++ b/jeedom-all-in-one/docker-entrypoint.sh
@@ -40,7 +40,7 @@ fi
 if [ "$JEEDOM_DB_HOST" = "localhost" ]
 then
   /usr/bin/mysqld_safe &
-  sleep 5
+  mysqladmin --silent --wait=30 ping || exit 1
 fi
 
 set_config() {


### PR DESCRIPTION
Wait 30s or until the MySQL daemon is ready. Exit properly on timeout.
